### PR TITLE
Add Microsoft Edge to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *yarn.lock
 node_modules/
 dist/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 
 <details>
 <summary><b>In Firefox</b></summary>
-
 1. Go to `about:debugging#/runtime/this-firefox`
 2. Click "Load Temporary Addon"
 3. Select `manifest.json` in the downloaded folder
@@ -38,6 +37,7 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 3. Click "Load Unpacked"
 4. Select the downloaded folder
 5. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
+
 
 **Specific browsers may have additional steps.**
 - In Opera, enable "Allow access to search page results"
@@ -53,7 +53,17 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 
 ## Usage
 - Click the extension icon to toggle 3D DOM view
-- Right-Click for options like showing sides, surfaces, randomising color, and enabling zoom.
+- Right-Click for options
+
+
+| Option                | Description                                            |
+|-----------------------|--------------------------------------------------------|
+| Show Sides            | Toggle visibility of element sides                     |
+| Show Surfaces         | Toggle visibility of element surfaces                  |
+| Randomize Color       | Apply random colors to elements                        |
+| Enable Zoom           | Enable zoom functionality                              |
+| Rotate with Alt+Drag  | Rotate view only when dragging and Alt key is pressed  |
+| Choose Selectors      | Select specific elements to apply effects              |
 
 ## Development
 1. Run `yarn install`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## dom3d
 
-A 3D DOM viewer for Firefox, Chrome, and Safari
+A 3D DOM viewer for Firefox, Chrome, Microsoft Edge, and Safari
 
 **NOTE: Only tested in Firefox and Chrome so far. Help with cross-browser support is welcome.**
 
@@ -9,7 +9,7 @@ Download the latest [release](https://github.com/OrionReed/dom3d/releases) and u
 
 <details>
 <summary><b>Tiny Bookmarklet version</b></summary>
-Simply prefix this code with `javascript:` and save it as a bookmark on Chrome or Firefox. This is a 1-1 equivelant to the full extension with the default configuration.
+Simply prefix this code with `javascript:` and save it as a bookmark on Chrome or Firefox. This is a 1-1 equivalent to the full extension with the default configuration.
 
 ```js
 (()=>{let e=t=>[...t.children].reduce((t,n)=>Math.max(t,e(n)),0)+1,t=e(document.body),n=(e,n=0,o=0)=>`hsl(${n}, 75%, ${Math.min(10+e*(1+60/t),90)+o}%)`,o=document.body;o.style.overflow="visible",o.style.transformStyle="preserve-3d",o.style.perspective=1e4;let r=window.innerWidth/2,i=window.innerHeight/2;o.style.perspectiveOrigin=o.style.transformOrigin=`${r}px ${i}px`,function e(t,o,r,i){for(let l=t.childNodes,s=l.length,d=0;d<s;d++){let s=l[d];if(1!==s.nodeType)continue;let f=n(o,190,-5);Object.assign(s.style,{transform:"translateZ(20px)",overflow:"visible",transformStyle:"preserve-3d",backgroundColor:f});let a=r,c=i;s.offsetParent===t&&(a+=t.offsetLeft,c+=t.offsetTop),e(s,o+1,a,c)}}(o,0,0,0),document.addEventListener("mousemove",e=>{let t=180*(1-e.clientY/window.innerHeight)-90,n=180*e.clientX/window.innerWidth-90;o.style.transform=`rotateX(${t}deg) rotateY(${n}deg)`})})();
@@ -26,6 +26,12 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 1. Go to `chrome://extensions`
 2. Click "Load Unpacked"
 3. Select the downloaded folder
+4. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
+
+**In Microsoft Edge**
+1. Go to `edge://extensions`
+2. Click "Load Unpacked"
+3. Select the downloaded folder. Please use the Chrome version of the extension.
 4. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 ## dom3d
 
-A 3D DOM viewer for Firefox, Chrome, Microsoft Edge, and Safari
+A 3D DOM viewer for the web.
 
-**NOTE: Only tested in Firefox and Chrome so far. Help with cross-browser support is welcome.**
+**Browser Support**
+- Chrome ✅
+- Firefox ✅
+- Microsoft Edge ✅
+- Opera ✅
+- Brave ✅
+- Safari ❌
 
 ## Install
-Download the latest [release](https://github.com/OrionReed/dom3d/releases) and unzip the file.
+Download the latest [release](https://github.com/OrionReed/dom3d/releases) and unzip the file then follow the instructions for your browser below.
 
 <details>
 <summary><b>Tiny Bookmarklet version</b></summary>
@@ -16,23 +22,34 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 ```
 </details>
 
-**In Firefox**
+<details>
+<summary><b>In Firefox</b></summary>
+
 1. Go to `about:debugging#/runtime/this-firefox`
 2. Click "Load Temporary Addon"
 3. Select `manifest.json` in the downloaded folder
 4. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
+</details>
 
-**In Chrome**
+<details>
+<summary><b>In Chrome/Chromium browsers</b></summary>
 1. Go to `chrome://extensions`
-2. Click "Load Unpacked"
-3. Select the downloaded folder
-4. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
+2. Enable "Developer Mode" in the top right
+3. Click "Load Unpacked"
+4. Select the downloaded folder
+5. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
 
-**In Microsoft Edge**
+**Specific browsers may have additional steps.**
+- In Opera, enable "Allow access to search page results"
+</details>
+
+<details>
+<summary><b>In Microsoft Edge</b></summary>
 1. Go to `edge://extensions`
 2. Click "Load Unpacked"
 3. Select the downloaded folder. Please use the Chrome version of the extension.
 4. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
+</details>
 
 ## Usage
 - Click the extension icon to toggle 3D DOM view

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A 3D DOM viewer for the web.
 - Brave ✅
 - Safari ❌
 
-## Install
+## Installation
 Download the latest [release](https://github.com/OrionReed/dom3d/releases) and unzip the file then follow the instructions for your browser below.
 
 <details>
@@ -36,10 +36,9 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 2. Enable "Developer Mode" in the top right
 3. Click "Load Unpacked"
 4. Select the downloaded folder
-5. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired
+5. Extension should now be installed, you can find it in the top right extensions menu (puzzle piece icon) and pin it if desired  
 
-
-**Specific browsers may have additional steps.**
+**Specific Chromium browsers may have additional steps.**
 - In Opera, enable "Allow access to search page results"
 </details>
 
@@ -52,9 +51,7 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 </details>
 
 ## Usage
-- Click the extension icon to toggle 3D DOM view
-- Right-Click for options
-
+Click the extension icon to toggle 3D DOM view or right-click for options.
 
 | Option                | Description                                            |
 |-----------------------|--------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-## dom3d
-
-A 3D DOM viewer for the web.
-
-**Browser Support**
-- Chrome ✅
-- Firefox ✅
-- Microsoft Edge ✅
-- Opera ✅
-- Brave ✅
-- Safari ❌
+<div align="center">
+  <img width="60" height="60" src="https://github.com/OrionReed/dom3d/assets/16704290/126a738c-1a22-43ac-a209-b465afe73b17"/>
+  <h3 style="margin-top: 0;">dom3d: a spatial DOM view for the web.</h3>
+  <img src="https://img.shields.io/badge/Chrome-Supported-brightgreen">
+  <img src="https://img.shields.io/badge/Firefox-Supported-brightgreen">
+  <img src="https://img.shields.io/badge/Microsoft%20Edge-Supported-brightgreen">
+  <img src="https://img.shields.io/badge/Opera-Supported-brightgreen">
+  <img src="https://img.shields.io/badge/Brave-Supported-brightgreen">
+  <img src="https://img.shields.io/badge/Safari-Unsupported-red">
+</div> 
 
 ## Installation
 Download the latest [release](https://github.com/OrionReed/dom3d/releases) and unzip the file then follow the instructions for your browser below.
 
 <details>
-<summary><b>Tiny Bookmarklet version</b></summary>
+<summary><b>Universal bookmarklet version</b></summary>
 Simply prefix this code with `javascript:` and save it as a bookmark on Chrome or Firefox. This is a 1-1 equivalent to the full extension with the default configuration.
 
 ```js


### PR DESCRIPTION
Hello there,

Feel free to close this PR without justification if this doesn't fit with your vision of the project :)

### Description

This PR adds some information in the README file to use the extension in Microsoft Edge; it works with the Chrome package directly.

Source: [Sideload an extension - Microsoft Edge Developer Extension](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/extension-sideloading).

Please note that this documentation could help you to publish the extension to their store too. I've done the process for https://github.com/julien-deramond/bootstrap-deprecated-classes-extension, and it was rather easy and quick.

Depending on what are the tests done, `**NOTE: Only tested in Firefox and Chrome so far. Help with cross-browser support is welcome.**` sentence could be modified too.

### Some screenshots

_Tested on MacOS 14.3.1 and Microsoft Edge 123.0.2420.65 (Official build) (arm64)_

<img width="1269" alt="Screenshot 2024-03-29 at 08 22 32" src="https://github.com/OrionReed/dom3d/assets/17381666/bbbf4b8b-9a1a-4a43-97fc-0361c4cdd1f2">

<img width="385" alt="Screenshot 2024-03-29 at 08 22 39" src="https://github.com/OrionReed/dom3d/assets/17381666/c54b69c1-d1c2-477d-9bf8-22acd6bb69d8">

<img width="1043" alt="Screenshot 2024-03-29 at 08 22 50" src="https://github.com/OrionReed/dom3d/assets/17381666/c0f9fac6-33ba-403c-977a-ada537e342ad">

