### PR TITLE
POC: Add proxy as an alternative to Browser extension

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,29 @@
+# Use the OpenResty image as the base
+FROM openresty/openresty:latest
+
+# Remove the default Nginx configuration file
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Create the nginx log directory and set permissions
+RUN mkdir -p /var/log/nginx && \
+    chown -R www-data:www-data /var/log/nginx
+
+
+# Copy the custom Nginx configuration file into the container
+COPY proxy/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+
+# Copy the main.lua modifier
+COPY proxy/modifiers /usr/local/openresty/nginx/modifiers
+
+# Copy the dom3d.js script
+COPY src/dom3d.js /usr/local/openresty/nginx/scripts/dom3d.js
+
+# Redirect Nginx Logs to stdout/stderr
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+ && ln -sf /dev/stderr /var/log/nginx/error.log
+
+# Expose port 80 to the host
+EXPOSE 80
+
+# Start OpenResty (which includes Nginx) when the container launches
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/proxy/fly.toml
+++ b/proxy/fly.toml
@@ -1,0 +1,20 @@
+# fly.toml app configuration file generated for dom3d on 2024-04-02T10:46:23-03:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'dom3d'
+primary_region = 'iad'
+
+[build]
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  size = 'shared-cpu-1x'

--- a/proxy/modifiers/main.lua
+++ b/proxy/modifiers/main.lua
@@ -1,0 +1,44 @@
+-- Import the dom3d.js file to inject it
+local file_path = "/usr/local/openresty/nginx/scripts/dom3d.js";
+local script = ""
+local f = io.open(file_path, "r")
+script = f:read("*all")
+f:close()
+
+-- Remove the export statement
+script = string.gsub(script, "export ", "")
+
+-- Replace % with %% to avoid string.format issues
+script = string.gsub(script, "%%", "%%%%")
+
+local html = ngx.arg[1]
+
+-- Default settings
+local showSides = false
+local colorSurfaces = true
+local colorRandom = false
+local requireDrag = true
+local requireAlt = false
+
+local run_dom3d_script = [[
+	window.addEventListener('load', function() {
+		dom3d(
+			]] .. tostring(showSides) .. [[,
+			]] .. tostring(colorSurfaces) .. [[,
+			]] .. tostring(colorRandom) .. [[,
+			]] .. tostring(requireDrag) .. [[,
+			]] .. tostring(requireAlt) .. [[,
+            [], // CSS Selectors
+		);
+	});
+]]
+
+local js_to_inject = [[
+    <script>
+]] .. script .. "\n\n" .. run_dom3d_script .. [[
+    </script>
+]]
+
+html = string.gsub(html, "</body>", js_to_inject .. "</body>")
+
+ngx.arg[1] = html

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -1,0 +1,83 @@
+user  www-data;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log info;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /usr/local/openresty/nginx/conf/mime.types;
+    default_type  application/octet-stream;
+
+    # Defines the format of the access log
+    log_format custom_format '[$time_local] $remote_addr - $remote_user "$request" '
+                             '$status $body_bytes_sent "$http_referer" '
+                             '"$http_user_agent" $host $request_uri '
+                             '$proxy_add_x_forwarded_for $upstream_addr $upstream_response_time';
+
+    # Configures the access log file path and log format
+    access_log /var/log/nginx/access.log custom_format;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+    proxy_buffer_size   64k;
+    proxy_buffers   4 64k;
+    proxy_busy_buffers_size   64k;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen 80;
+        location = /p {
+            default_type     text/html;
+            set $target_url $arg_uri;
+            set_unescape_uri $target_url;
+
+            # Add https if protocol not present
+            if ($target_url !~ '^https?://') {
+                set $target_url "https://$target_url";
+            }
+
+            # Add trailing slash if not present
+            if ($target_url ~ '^\w+:\/\/[^\/]+$') {
+                set $target_url "$target_url/";
+            }
+
+            resolver         8.8.8.8 ipv6=off;
+
+            proxy_ssl_server_name       on;
+            proxy_set_header            X-Real-IP       $remote_addr;
+            proxy_set_header            X-Forwared-For  $proxy_add_x_forwarded_for;
+            proxy_hide_header           'X-XSS-Protection';
+
+            proxy_pass                  $target_url;
+            proxy_set_header            Accept-Encoding "";
+            proxy_set_header            Referer $target_url;
+            proxy_redirect              ~^(.*)$    $scheme://$host/p?uri=$1;
+
+            # Inject base tag
+            sub_filter '<head>' '<head><base href="$target_url">';
+
+            # Inject dom3d
+            body_filter_by_lua_file 'modifiers/main.lua';
+
+            # Enable HSTS
+            more_set_headers 'X-Content-Type-Options: nosniff';
+
+            # Enable XSS protection
+            more_set_headers 'X-XSS-Protection:1; mode=block';
+
+            # Allow cross-origin requests
+            more_set_headers 'Access-Control-Allow-Origin: *';
+
+            # Allow inline scripts
+            more_set_headers 'Content-Security-Policy: script-src \'self\' \'unsafe-inline\'; object-src \'self\'';
+        }
+    }
+}


### PR DESCRIPTION
I've been working with reverse proxies the last week and I think it would be useful to implement one here.

Via NGINX + OpenResty we can:
- Modify the headers of the page (enabling inline scripts, or allowing to put it in an iframe, and much more that maybe can't be done with a simple browser extension)
- Inject the `dom3d.js` script via `body_filter_by_lua_file`
- Make the browser believe the page domain is actually the requested
- Deploy somewhere and make these amazing 3D websites public :)

This PR also includes a Dockerfile to easily run it, and a `fly.toml` as an example on how to deploy it.

I've deployed one. Here are a few examples:

https://dom3d.fly.dev/p?uri=https://www.cacoos.com/
https://dom3d.fly.dev/p?uri=google.com

This is just a POC. If you think it could be useful, would love to add more docs.

Here you can setup locally:

- Build: `docker build -t nginx-proxy -f proxy/Dockerfile .` (we need it to be from main directory so we have access to the `dom3d.js` file)
- Run: `docker run -p 9000:80 -it nginx-proxy` (port 80 mapped to 9000)
- Go to `localhost:9000/p?uri=example.com`

If you want to deploy, install the flyctl CLI and use `fly launch`

Screenshots:

https://dom3d.fly.dev/p?uri=google.com
<img width="1211" alt="Screenshot 2024-04-02 at 11 59 26" src="https://github.com/OrionReed/dom3d/assets/30879716/b0cbef9b-1beb-4d80-8918-15e8979a67e6">
