### PR TITLE
Fix 'yarn watch' command not working on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:chrome": "node build.js chrome",
     "build:safari": "node build.js safari",
     "build": "yarn build:firefox && yarn build:chrome && yarn build:safari",
-    "watch": "nodemon --ignore 'dist/*' --watch 'src/**/*' --watch 'manifest-*.json' --watch 'manifest.json' --exec 'yarn build'"
+    "watch": "nodemon --ignore 'dist/*' --watch 'src/**/*' --watch 'manifest-*.json' --watch 'manifest.json' --exec \"yarn build\""
   },
   "license": "GPL-3.0",
   "devDependencies": {


### PR DESCRIPTION
Before, the nodemon --exec option on the 'yarn watch' command had single quotes, which doesn't work on windows.
Now, I changed to double quotes, so it will work on all operational systems.